### PR TITLE
Move preamble printing out of calculate_seconds

### DIFF
--- a/countdown
+++ b/countdown
@@ -98,17 +98,9 @@ def calculate_seconds(time_str):
         return 0
 
     if ':' in time_str:
-        seconds = seconds_until(time_str)
+        return seconds_until(time_str)
     else:
-        seconds = seconds_in(time_str)
-
-    if seconds > 0:
-        finishing_time = (datetime.now()
-                          + timedelta(seconds=seconds)).strftime('%Y-%m-%d %H:%M:%S')
-
-        print("Counting down {} seconds until {}".format(seconds, finishing_time))
-
-    return seconds
+        return seconds_in(time_str)
 
 
 # Set up command line arguments
@@ -130,7 +122,11 @@ args = parser.parse_args()
 
 seconds = calculate_seconds(args.time)
 
-if seconds < 0:
+if seconds > 0:
+    finishing_time = (datetime.now()
+                      + timedelta(seconds=seconds)).strftime('%Y-%m-%d %H:%M:%S')
+    print("Counting down {} seconds until {}".format(seconds, finishing_time))
+elif seconds < 0:
     print("Unable to parse time duration '{}'".format(args.time))
     sys.exit(1)
 


### PR DESCRIPTION
This allows better brevity of the code, and also restricts the
`calculate_seconds` function to do only what it is supposed to.